### PR TITLE
fix CI workflow caching by reordering checkout and setup-go steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.20
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.22"
-        id: go
-
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+        id: go
+
       - name: build and test
         run: |
-          go get -v
           go test -timeout=300s -race -covermode=atomic -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp ./...
           cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
           go build -race
@@ -32,7 +31,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0.2
+          version: v2.6
 
       - name: install goveralls
         run: go install github.com/mattn/goveralls@latest


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- Update actions/checkout to v4 and actions/setup-go to v5
- Update golangci-lint-action to v7 with version v2.6