### PR TITLE
Add E-suffix container variants for TestMain usage

### DIFF
--- a/containers/mysql.go
+++ b/containers/mysql.go
@@ -27,8 +27,22 @@ func NewMySQLTestContainer(ctx context.Context, t *testing.T) *MySQLTestContaine
 	return NewMySQLTestContainerWithDB(ctx, t, "test")
 }
 
+// NewMySQLTestContainerE creates a new MySQL test container with default settings.
+// Returns error instead of using require.NoError, suitable for TestMain usage.
+func NewMySQLTestContainerE(ctx context.Context) (*MySQLTestContainer, error) {
+	return NewMySQLTestContainerWithDBE(ctx, "test")
+}
+
 // NewMySQLTestContainerWithDB creates a new MySQL test container with a specific database name
 func NewMySQLTestContainerWithDB(ctx context.Context, t *testing.T, dbName string) *MySQLTestContainer {
+	mc, err := NewMySQLTestContainerWithDBE(ctx, dbName)
+	require.NoError(t, err)
+	return mc
+}
+
+// NewMySQLTestContainerWithDBE creates a new MySQL test container with a specific database name.
+// Returns error instead of using require.NoError, suitable for TestMain usage.
+func NewMySQLTestContainerWithDBE(ctx context.Context, dbName string) (*MySQLTestContainer, error) {
 	const (
 		defaultUser     = "root"
 		defaultPassword = "secret"
@@ -51,13 +65,21 @@ func NewMySQLTestContainerWithDB(ctx context.Context, t *testing.T, dbName strin
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mysql container: %w", err)
+	}
 
 	host, err := container.Host(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, fmt.Errorf("failed to get container host: %w", err)
+	}
 
 	port, err := container.MappedPort(ctx, "3306")
-	require.NoError(t, err)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, fmt.Errorf("failed to get mapped port: %w", err)
+	}
 
 	return &MySQLTestContainer{
 		Container: container,
@@ -66,7 +88,7 @@ func NewMySQLTestContainerWithDB(ctx context.Context, t *testing.T, dbName strin
 		User:      defaultUser,
 		Password:  defaultPassword,
 		Database:  dbName,
-	}
+	}, nil
 }
 
 // ConnectionString returns the MySQL connection string for this container

--- a/containers/psql.go
+++ b/containers/psql.go
@@ -27,8 +27,22 @@ func NewPostgresTestContainer(ctx context.Context, t *testing.T) *PostgresTestCo
 	return NewPostgresTestContainerWithDB(ctx, t, "test")
 }
 
+// NewPostgresTestContainerE creates a new PostgreSQL test container with default settings.
+// Returns error instead of using require.NoError, suitable for TestMain usage.
+func NewPostgresTestContainerE(ctx context.Context) (*PostgresTestContainer, error) {
+	return NewPostgresTestContainerWithDBE(ctx, "test")
+}
+
 // NewPostgresTestContainerWithDB creates a new PostgreSQL test container with a specific database name
 func NewPostgresTestContainerWithDB(ctx context.Context, t *testing.T, dbName string) *PostgresTestContainer {
+	pc, err := NewPostgresTestContainerWithDBE(ctx, dbName)
+	require.NoError(t, err)
+	return pc
+}
+
+// NewPostgresTestContainerWithDBE creates a new PostgreSQL test container with a specific database name.
+// Returns error instead of using require.NoError, suitable for TestMain usage.
+func NewPostgresTestContainerWithDBE(ctx context.Context, dbName string) (*PostgresTestContainer, error) {
 	const (
 		defaultUser     = "postgres"
 		defaultPassword = "secret"
@@ -51,13 +65,21 @@ func NewPostgresTestContainerWithDB(ctx context.Context, t *testing.T, dbName st
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create postgres container: %w", err)
+	}
 
 	host, err := container.Host(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, fmt.Errorf("failed to get container host: %w", err)
+	}
 
 	port, err := container.MappedPort(ctx, "5432")
-	require.NoError(t, err)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return nil, fmt.Errorf("failed to get mapped port: %w", err)
+	}
 
 	return &PostgresTestContainer{
 		Container: container,
@@ -66,7 +88,7 @@ func NewPostgresTestContainerWithDB(ctx context.Context, t *testing.T, dbName st
 		User:      defaultUser,
 		Password:  defaultPassword,
 		Database:  dbName,
-	}
+	}, nil
 }
 
 // ConnectionString returns the PostgreSQL connection string for this container


### PR DESCRIPTION
**Summary**

Add error-returning variants (E-suffix) of all container constructors for use in TestMain where `*testing.T` is not available.

**Changes**

- Add E-suffix variants for all 6 container types (PostgreSQL, MySQL, MongoDB, SSH, FTP, Localstack)
- E variants return `(*Container, error)` instead of using `require.NoError` internally
- Original variants now delegate to E variants + `require.NoError(t, err)`
- Ensure proper container termination on all error paths
- Fix: restore original `MONGO_TEST` env value if `mongo.Connect` fails
- Update README with TestMain example and E-suffix variants table

**E-suffix variants added**

| Standard | Error-returning |
|----------|-----------------|
| `NewPostgresTestContainer` | `NewPostgresTestContainerE` |
| `NewPostgresTestContainerWithDB` | `NewPostgresTestContainerWithDBE` |
| `NewMySQLTestContainer` | `NewMySQLTestContainerE` |
| `NewMySQLTestContainerWithDB` | `NewMySQLTestContainerWithDBE` |
| `NewMongoTestContainer` | `NewMongoTestContainerE` |
| `NewSSHTestContainer` | `NewSSHTestContainerE` |
| `NewSSHTestContainerWithUser` | `NewSSHTestContainerWithUserE` |
| `NewFTPTestContainer` | `NewFTPTestContainerE` |
| `NewLocalstackTestContainer` | `NewLocalstackTestContainerE` |